### PR TITLE
S3/feature/information store in conversations

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -243,7 +243,7 @@ class Agent
             }
         }
 
-        $this->logger->info(sprintf('No supporting Store found for information request %', $action_id));
+        $this->logger->info(sprintf('No supporting actuator found for action %', $action_id));
         return null;
     }
 
@@ -251,14 +251,14 @@ class Agent
      * Loops through all available information requests and if they support the requested
      *
      * @param $information_request_id
-     * @param Map $utterance
+     * @param Map $arguments
      * @return mixed|null
      */
-    public function performInformationRequest($information_request_id, Map $utterance)
+    public function performInformationRequest($information_request_id, Map $arguments)
     {
         foreach ($this->information_requests as $store => $information_request_ids) {
             if (in_array($information_request_id, $information_request_ids)) {
-                return $this->getStore($store)->getInformation($information_request_id, $utterance);
+                return $this->getStore($store)->getInformation($information_request_id, $arguments);
             }
         }
 

--- a/src/Conversations/BaseConversationalInstance.php
+++ b/src/Conversations/BaseConversationalInstance.php
@@ -80,6 +80,9 @@ abstract class BaseConversationalInstance implements ConversationInstanceInterfa
         return $this->conversation;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function setCurrentUtteranceSequenceId($current_utterance_sequence_id)
     {
         $this->current_utterance_sequence_id = $current_utterance_sequence_id;
@@ -91,6 +94,9 @@ abstract class BaseConversationalInstance implements ConversationInstanceInterfa
         return $this->current_utterance_sequence_id;
     }
 
+    /**
+     * @return Utterance
+     */
     public function getCurrentUtterance()
     {
         return $this->conversation->getUtteranceWithSequence($this->current_utterance_sequence_id);
@@ -99,6 +105,14 @@ abstract class BaseConversationalInstance implements ConversationInstanceInterfa
     public function getCurrentAction()
     {
         return $this->getCurrentUtterance()->getAction();
+    }
+
+    /**
+     * Gets the information request on the current Utterance if there is one
+     */
+    public function getCurrentInformationRequest()
+    {
+        return $this->getCurrentUtterance()->getInformationRequest();
     }
 
     /**

--- a/src/Conversations/ConversationInstanceInterface.php
+++ b/src/Conversations/ConversationInstanceInterface.php
@@ -25,6 +25,10 @@ interface ConversationInstanceInterface
 
     public function getConversation();
 
+    /**
+     * @param $current_utterance_sequence_id
+     * @return ConversationInstanceInterface
+     */
     public function setCurrentUtteranceSequenceId($current_utterance_sequence_id);
 
     public function getCurrentUtteranceSequenceId();

--- a/src/Conversations/Utterance.php
+++ b/src/Conversations/Utterance.php
@@ -6,10 +6,6 @@ use actsmart\actsmart\Interpreters\Intent\Intent;
 use Ds\Map;
 use Fhaculty\Graph\Edge\Directed as EdgeDirected;
 use Fhaculty\Graph\Vertex;
-use actsmart\actsmart\Interpreters\Intent\IntentInterpreter;
-use actsmart\actsmart\Actions\ActionInterface;
-use actsmart\actsmart\Conversations\ConditionInterface;
-use actsmart\actsmart\Sensors\SensorEvent;
 
 class Utterance extends EdgeDirected
 {
@@ -17,11 +13,14 @@ class Utterance extends EdgeDirected
 
     private $sequence;
 
+    /** @var Intent */
     private $intent;
 
     private $completes;
 
     private $action;
+
+    private $informationRequest;
 
     private $preconditions = [];
 
@@ -82,6 +81,7 @@ class Utterance extends EdgeDirected
 
     /**
      * @param mixed $completes
+     * @return Utterance
      */
     public function setCompletes($completes)
     {
@@ -90,7 +90,7 @@ class Utterance extends EdgeDirected
     }
 
     /**
-     * @return ActionInterface
+     * @return string
      */
     public function getAction()
     {
@@ -104,6 +104,24 @@ class Utterance extends EdgeDirected
     public function setAction($action)
     {
         $this->action = $action;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getInformationRequest()
+    {
+        return $this->informationRequest;
+    }
+
+    /**
+     * @param mixed $informationRequest
+     * @return Utterance
+     */
+    public function setInformationRequest($informationRequest)
+    {
+        $this->informationRequest = $informationRequest;
         return $this;
     }
 

--- a/src/NLPInterpretDoesNotExistException.php
+++ b/src/NLPInterpretDoesNotExistException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace actsmart\actsmart;
+
+use InvalidArgumentException;
+
+class NLPInterpretDoesNotExistException extends InvalidArgumentException
+{
+    //
+}

--- a/src/Sensors/WebChat/WebChatSensor.php
+++ b/src/Sensors/WebChat/WebChatSensor.php
@@ -68,7 +68,7 @@ class WebChatSensor implements SensorInterface, NotifierInterface, ComponentInte
             $event_type = WebChatEventCreator::LONGTEXT_RESPONSE;
         } else if ($message->type == WebChatEventCreator::CHAT_OPEN) {
             $event_type = WebChatEventCreator::CHAT_OPEN;
-        } else if (isset($message->callback_id)) {
+        } else if (isset($message->data->callback_id)) {
             $event_type = WebChatEventCreator::ACTION;
         }
 

--- a/src/Stores/BaseStore.php
+++ b/src/Stores/BaseStore.php
@@ -2,13 +2,39 @@
 
 namespace actsmart\actsmart\Stores;
 
-class BaseStore
+use actsmart\actsmart\Utils\ComponentInterface;
+use actsmart\actsmart\Utils\ComponentTrait;
+use Ds\Map;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+
+abstract class BaseStore implements LoggerAwareInterface, ComponentInterface, StoreInterface
 {
-    public function store($data)
+    use LoggerAwareTrait, ComponentTrait;
+
+    /**
+     * The logger instance.
+     *
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @inheritdoc
+     */
+    public function getInformation($information_request_id, Map $arguments)
     {
+        return null;
     }
 
-    public function retrieve()
+    /**
+     * This is here as a default for stores that do not support information requests
+     *
+     * @inheritdoc
+     */
+    public function handlesInformationRequests()
     {
+        return [];
     }
 }

--- a/src/Stores/ConfigStore.php
+++ b/src/Stores/ConfigStore.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * [topic][key][value]. The added topic level allows us to store multiple configuration settings
  * relating to a specific group or context.
  */
-class ConfigStore implements ComponentInterface, StoreInterface, ListenerInterface, NotifierInterface
+class ConfigStore extends BaseStore implements ComponentInterface, ListenerInterface, NotifierInterface
 {
     use ComponentTrait, NotifierTrait, ListenerTrait;
 

--- a/src/Stores/ContextStore.php
+++ b/src/Stores/ContextStore.php
@@ -9,7 +9,7 @@ use actsmart\actsmart\Utils\ListenerInterface;
 use actsmart\actsmart\Utils\ListenerTrait;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-class ContextStore implements ComponentInterface, ListenerInterface, StoreInterface
+class ContextStore extends BaseStore implements ComponentInterface, ListenerInterface
 {
     use ComponentTrait, ListenerTrait;
 

--- a/src/Stores/ConversationTemplateStore.php
+++ b/src/Stores/ConversationTemplateStore.php
@@ -3,16 +3,18 @@
 namespace actsmart\actsmart\Stores;
 
 use actsmart\actsmart\Conversations\Conversation;
+use actsmart\actsmart\Conversations\Scene;
 use actsmart\actsmart\Conversations\Utterance;
 use actsmart\actsmart\Interpreters\Intent\Intent;
 use actsmart\actsmart\Utils\ComponentInterface;
 use actsmart\actsmart\Utils\ComponentTrait;
 use Ds\Map;
 
-abstract class ConversationTemplateStore implements ConversationTemplateStoreInterface, ComponentInterface, StoreInterface
+abstract class ConversationTemplateStore extends BaseStore implements ConversationTemplateStoreInterface, ComponentInterface, StoreInterface
 {
     use ComponentTrait;
 
+    /** @var Conversation[] */
     protected $conversations = [];
 
     /**
@@ -48,7 +50,9 @@ abstract class ConversationTemplateStore implements ConversationTemplateStoreInt
     {
         $matches = [];
         foreach ($this->conversations as $conversation) {
-                $scene = $conversation->getInitialScene();
+
+            /** @var Scene $scene */
+            $scene = $conversation->getInitialScene();
 
             // Check preconditions and if good then check interpreter
             if ($this->getAgent()->checkIntentConditions($scene->getPreconditions(), $utterance)) {

--- a/src/Stores/DynamoConversationInstanceStore.php
+++ b/src/Stores/DynamoConversationInstanceStore.php
@@ -7,7 +7,7 @@ use actsmart\actsmart\Utils\ComponentInterface;
 use actsmart\actsmart\Utils\ComponentTrait;
 use Aws\DynamoDb\DynamoDbClient;
 
-class DynamoConversationInstanceStore implements ComponentInterface, StoreInterface
+class DynamoConversationInstanceStore extends BaseStore implements ComponentInterface, StoreInterface
 {
     use ComponentTrait;
 
@@ -42,7 +42,7 @@ class DynamoConversationInstanceStore implements ComponentInterface, StoreInterf
         ];
 
         try {
-            $result = $this->client->putItem([
+            $this->client->putItem([
                 'TableName' => $this->table_name,
                 'Item' => $ci_record,
             ]);
@@ -119,7 +119,7 @@ class DynamoConversationInstanceStore implements ComponentInterface, StoreInterf
                 )
             ));
         } catch (\Exception $e) {
-            dd($e->getMessage());
+            $this->logger->error(sprintf("Error deleting conversation ", $e->getMessage()));
         }
     }
 

--- a/src/Stores/StoreInterface.php
+++ b/src/Stores/StoreInterface.php
@@ -1,8 +1,21 @@
 <?php
 namespace actsmart\actsmart\Stores;
 
+use Ds\Map;
+
 interface StoreInterface
 {
-    //Used just to tag stores for now.
-    //@todo determine common elements for store functionality.
+    /**
+     * @param $information_request_id string The id of the
+     * @param $arguments
+     * @return mixed
+     */
+    public function getInformation($information_request_id, Map $arguments);
+
+    /**
+     * Returns an array of information requests that will be listened to
+     *
+     * @return string[]
+     */
+    public function handlesInformationRequests();
 }


### PR DESCRIPTION
Adds a BaseStore that implements defaults for the methods required by the interface
Adds functionality to get supported information requests
adds information_response to the webchat conversation controller to be used in messages
some fixes for warnings

I've put in a couple of fixes to reduce warnings as well and will try to do so with each PR to actsmart